### PR TITLE
Add EcoDeli mobile prestataire app skeleton

### DIFF
--- a/PA/mobilePrestataires/app/build.gradle
+++ b/PA/mobilePrestataires/app/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    compileSdk 33
+    defaultConfig {
+        applicationId "com.example.ecodeli"
+        minSdk 24
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.0'
+    }
+    packagingOptions {
+        resources {
+            excludes += '/META-INF/{AL2.0,LGPL2.1}'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.activity:activity-compose:1.7.2'
+    implementation 'androidx.compose.ui:ui:1.5.0'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.5.0'
+    implementation 'androidx.compose.material3:material3:1.1.1'
+    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.itextpdf:itext7-core:7.2.5'
+}

--- a/PA/mobilePrestataires/app/src/main/AndroidManifest.xml
+++ b/PA/mobilePrestataires/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.ecodeli">
+
+    <application
+        android:allowBackup="true"
+        android:label="EcoDeli"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity android:name="com.example.ecodeli.ui.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/PA/mobilePrestataires/app/src/main/assets/data.json
+++ b/PA/mobilePrestataires/app/src/main/assets/data.json
@@ -1,0 +1,302 @@
+[
+  {
+    "id": 1,
+    "title": "Prestation 1",
+    "type": "Nettoyage",
+    "client": "Client2",
+    "date": "2024-01-01",
+    "statut": "EN_COURS",
+    "duree": 31,
+    "prix": 21.5
+  },
+  {
+    "id": 2,
+    "title": "Prestation 2",
+    "type": "Reparation",
+    "client": "Client3",
+    "date": "2024-01-02",
+    "statut": "ANNULE",
+    "duree": 32,
+    "prix": 23.0
+  },
+  {
+    "id": 3,
+    "title": "Prestation 3",
+    "type": "Livraison",
+    "client": "Client4",
+    "date": "2024-01-03",
+    "statut": "TERMINE",
+    "duree": 33,
+    "prix": 24.5
+  },
+  {
+    "id": 4,
+    "title": "Prestation 4",
+    "type": "Nettoyage",
+    "client": "Client5",
+    "date": "2024-01-04",
+    "statut": "EN_COURS",
+    "duree": 34,
+    "prix": 26.0
+  },
+  {
+    "id": 5,
+    "title": "Prestation 5",
+    "type": "Reparation",
+    "client": "Client1",
+    "date": "2024-01-05",
+    "statut": "ANNULE",
+    "duree": 35,
+    "prix": 27.5
+  },
+  {
+    "id": 6,
+    "title": "Prestation 6",
+    "type": "Livraison",
+    "client": "Client2",
+    "date": "2024-01-06",
+    "statut": "TERMINE",
+    "duree": 36,
+    "prix": 29.0
+  },
+  {
+    "id": 7,
+    "title": "Prestation 7",
+    "type": "Nettoyage",
+    "client": "Client3",
+    "date": "2024-01-07",
+    "statut": "EN_COURS",
+    "duree": 37,
+    "prix": 30.5
+  },
+  {
+    "id": 8,
+    "title": "Prestation 8",
+    "type": "Reparation",
+    "client": "Client4",
+    "date": "2024-01-08",
+    "statut": "ANNULE",
+    "duree": 38,
+    "prix": 32.0
+  },
+  {
+    "id": 9,
+    "title": "Prestation 9",
+    "type": "Livraison",
+    "client": "Client5",
+    "date": "2024-01-09",
+    "statut": "TERMINE",
+    "duree": 39,
+    "prix": 33.5
+  },
+  {
+    "id": 10,
+    "title": "Prestation 10",
+    "type": "Nettoyage",
+    "client": "Client1",
+    "date": "2024-01-10",
+    "statut": "EN_COURS",
+    "duree": 40,
+    "prix": 35.0
+  },
+  {
+    "id": 11,
+    "title": "Prestation 11",
+    "type": "Reparation",
+    "client": "Client2",
+    "date": "2024-01-11",
+    "statut": "ANNULE",
+    "duree": 41,
+    "prix": 36.5
+  },
+  {
+    "id": 12,
+    "title": "Prestation 12",
+    "type": "Livraison",
+    "client": "Client3",
+    "date": "2024-01-12",
+    "statut": "TERMINE",
+    "duree": 42,
+    "prix": 38.0
+  },
+  {
+    "id": 13,
+    "title": "Prestation 13",
+    "type": "Nettoyage",
+    "client": "Client4",
+    "date": "2024-01-13",
+    "statut": "EN_COURS",
+    "duree": 43,
+    "prix": 39.5
+  },
+  {
+    "id": 14,
+    "title": "Prestation 14",
+    "type": "Reparation",
+    "client": "Client5",
+    "date": "2024-01-14",
+    "statut": "ANNULE",
+    "duree": 44,
+    "prix": 41.0
+  },
+  {
+    "id": 15,
+    "title": "Prestation 15",
+    "type": "Livraison",
+    "client": "Client1",
+    "date": "2024-01-15",
+    "statut": "TERMINE",
+    "duree": 45,
+    "prix": 42.5
+  },
+  {
+    "id": 16,
+    "title": "Prestation 16",
+    "type": "Nettoyage",
+    "client": "Client2",
+    "date": "2024-01-16",
+    "statut": "EN_COURS",
+    "duree": 46,
+    "prix": 44.0
+  },
+  {
+    "id": 17,
+    "title": "Prestation 17",
+    "type": "Reparation",
+    "client": "Client3",
+    "date": "2024-01-17",
+    "statut": "ANNULE",
+    "duree": 47,
+    "prix": 45.5
+  },
+  {
+    "id": 18,
+    "title": "Prestation 18",
+    "type": "Livraison",
+    "client": "Client4",
+    "date": "2024-01-18",
+    "statut": "TERMINE",
+    "duree": 48,
+    "prix": 47.0
+  },
+  {
+    "id": 19,
+    "title": "Prestation 19",
+    "type": "Nettoyage",
+    "client": "Client5",
+    "date": "2024-01-19",
+    "statut": "EN_COURS",
+    "duree": 49,
+    "prix": 48.5
+  },
+  {
+    "id": 20,
+    "title": "Prestation 20",
+    "type": "Reparation",
+    "client": "Client1",
+    "date": "2024-01-20",
+    "statut": "ANNULE",
+    "duree": 50,
+    "prix": 50.0
+  },
+  {
+    "id": 21,
+    "title": "Prestation 21",
+    "type": "Livraison",
+    "client": "Client2",
+    "date": "2024-01-21",
+    "statut": "TERMINE",
+    "duree": 51,
+    "prix": 51.5
+  },
+  {
+    "id": 22,
+    "title": "Prestation 22",
+    "type": "Nettoyage",
+    "client": "Client3",
+    "date": "2024-01-22",
+    "statut": "EN_COURS",
+    "duree": 52,
+    "prix": 53.0
+  },
+  {
+    "id": 23,
+    "title": "Prestation 23",
+    "type": "Reparation",
+    "client": "Client4",
+    "date": "2024-01-23",
+    "statut": "ANNULE",
+    "duree": 53,
+    "prix": 54.5
+  },
+  {
+    "id": 24,
+    "title": "Prestation 24",
+    "type": "Livraison",
+    "client": "Client5",
+    "date": "2024-01-24",
+    "statut": "TERMINE",
+    "duree": 54,
+    "prix": 56.0
+  },
+  {
+    "id": 25,
+    "title": "Prestation 25",
+    "type": "Nettoyage",
+    "client": "Client1",
+    "date": "2024-01-25",
+    "statut": "EN_COURS",
+    "duree": 55,
+    "prix": 57.5
+  },
+  {
+    "id": 26,
+    "title": "Prestation 26",
+    "type": "Reparation",
+    "client": "Client2",
+    "date": "2024-01-26",
+    "statut": "ANNULE",
+    "duree": 56,
+    "prix": 59.0
+  },
+  {
+    "id": 27,
+    "title": "Prestation 27",
+    "type": "Livraison",
+    "client": "Client3",
+    "date": "2024-01-27",
+    "statut": "TERMINE",
+    "duree": 57,
+    "prix": 60.5
+  },
+  {
+    "id": 28,
+    "title": "Prestation 28",
+    "type": "Nettoyage",
+    "client": "Client4",
+    "date": "2024-01-28",
+    "statut": "EN_COURS",
+    "duree": 58,
+    "prix": 62.0
+  },
+  {
+    "id": 29,
+    "title": "Prestation 29",
+    "type": "Reparation",
+    "client": "Client5",
+    "date": "2024-01-29",
+    "statut": "ANNULE",
+    "duree": 59,
+    "prix": 63.5
+  },
+  {
+    "id": 30,
+    "title": "Prestation 30",
+    "type": "Livraison",
+    "client": "Client1",
+    "date": "2024-01-30",
+    "statut": "TERMINE",
+    "duree": 60,
+    "prix": 65.0
+  }
+]

--- a/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/model/Prestation.kt
+++ b/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/model/Prestation.kt
@@ -1,0 +1,12 @@
+package com.example.ecodeli.model
+
+data class Prestation(
+    val id: Int,
+    val title: String,
+    val type: String,
+    val client: String,
+    val date: String,
+    val statut: String,
+    val duree: Int,
+    val prix: Double
+)

--- a/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/ui/MainActivity.kt
+++ b/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/ui/MainActivity.kt
@@ -1,0 +1,78 @@
+package com.example.ecodeli.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.ecodeli.model.Prestation
+import com.example.ecodeli.utils.JsonReader
+import com.example.ecodeli.utils.PdfGenerator
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val prestations = JsonReader.loadPrestations(this)
+        setContent {
+            MaterialTheme {
+                PrestationsScreen(prestations = prestations) {
+                    PdfGenerator.generateReport(this, prestations)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PrestationsScreen(prestations: List<Prestation>, onPdf: () -> Unit) {
+    var selected by remember { mutableStateOf<Prestation?>(null) }
+
+    if (selected == null) {
+        Column {
+            Button(onClick = onPdf, modifier = Modifier.fillMaxWidth()) {
+                Text("Generer PDF")
+            }
+            LazyColumn {
+                items(prestations) { p ->
+                    Row(modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { selected = p }
+                        .padding(16.dp)) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(p.title, style = MaterialTheme.typography.titleMedium)
+                            Text(p.type)
+                            Text(p.client)
+                            Text(p.date)
+                            Text(p.statut)
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        PrestationDetail(prestation = selected!!) { selected = null }
+    }
+}
+
+@Composable
+fun PrestationDetail(prestation: Prestation, onBack: () -> Unit) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(prestation.title, style = MaterialTheme.typography.titleLarge)
+        Text("Type: ${prestation.type}")
+        Text("Client: ${prestation.client}")
+        Text("Date: ${prestation.date}")
+        Text("Statut: ${prestation.statut}")
+        Text("Durée: ${prestation.duree} min")
+        Text("Prix: ${prestation.prix}€")
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onBack) {
+            Text("Retour")
+        }
+    }
+}

--- a/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/utils/JsonReader.kt
+++ b/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/utils/JsonReader.kt
@@ -1,0 +1,15 @@
+package com.example.ecodeli.utils
+
+import android.content.Context
+import com.example.ecodeli.model.Prestation
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+object JsonReader {
+    fun loadPrestations(context: Context): List<Prestation> {
+        val input = context.assets.open("data.json")
+        val json = input.bufferedReader().use { it.readText() }
+        val type = object : TypeToken<List<Prestation>>() {}.type
+        return Gson().fromJson(json, type)
+    }
+}

--- a/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/utils/PdfGenerator.kt
+++ b/PA/mobilePrestataires/app/src/main/java/com/example/ecodeli/utils/PdfGenerator.kt
@@ -1,0 +1,41 @@
+package com.example.ecodeli.utils
+
+import android.content.Context
+import com.example.ecodeli.model.Prestation
+import com.itextpdf.kernel.pdf.PdfWriter
+import com.itextpdf.layout.Document
+import com.itextpdf.layout.element.Paragraph
+import com.itextpdf.layout.element.Image
+import com.itextpdf.io.image.ImageDataFactory
+import java.io.File
+
+object PdfGenerator {
+    fun generateReport(context: Context, prestations: List<Prestation>): File {
+        val file = File(context.filesDir, "rapport_prestations.pdf")
+        val writer = PdfWriter(file)
+        val pdf = com.itextpdf.kernel.pdf.PdfDocument(writer)
+        val document = Document(pdf)
+
+        document.add(Paragraph("Rapport des Prestations"))
+
+        // Placeholder: here you would generate your charts as bitmap images and add them
+        for (i in 1..8) {
+            val bmp = android.graphics.Bitmap.createBitmap(400,200, android.graphics.Bitmap.Config.ARGB_8888)
+            val canvas = android.graphics.Canvas(bmp)
+            val paint = android.graphics.Paint()
+            paint.textSize = 24f
+            canvas.drawText("Graphique $i",50f,100f,paint)
+            val img = ImageDataFactory.create(bmpToBytes(bmp))
+            document.add(Image(img))
+        }
+
+        document.close()
+        return file
+    }
+
+    private fun bmpToBytes(bmp: android.graphics.Bitmap): ByteArray {
+        val stream = java.io.ByteArrayOutputStream()
+        bmp.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, stream)
+        return stream.toByteArray()
+    }
+}

--- a/PA/mobilePrestataires/build.gradle
+++ b/PA/mobilePrestataires/build.gradle
@@ -1,0 +1,20 @@
+buildscript {
+    ext {
+        compose_ui_version = '1.5.0'
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.0.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/PA/mobilePrestataires/settings.gradle
+++ b/PA/mobilePrestataires/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name='EcoDeli'


### PR DESCRIPTION
## Summary
- create Android project skeleton for `EcoDeli` prestataire mobile app
- implement Prestation model and JSON reader
- implement Compose UI to list and display prestations
- add PDF generator using iText with placeholder charts
- include sample `data.json` with 30 prestations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dcabd64188322854e0a624cf6e47f