### PR TITLE
Update Android configs for SDK 34

### DIFF
--- a/PA/mobilePrestataires/app/build.gradle
+++ b/PA/mobilePrestataires/app/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace "com.example.ecodeli"
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.ecodeli"
         minSdk 24
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
     }
@@ -21,8 +21,15 @@ android {
     buildFeatures {
         compose true
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
+        kotlinCompilerExtensionVersion rootProject.ext.compose_ui_version
     }
     packagingOptions {
         resources {
@@ -34,9 +41,13 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.activity:activity-compose:1.7.2'
-    implementation 'androidx.compose.ui:ui:1.5.0'
-    implementation 'androidx.compose.ui:ui-tooling-preview:1.5.0'
+    def composeVersion = rootProject.ext.compose_ui_version
+    implementation "androidx.compose.ui:ui:$composeVersion"
+    implementation "androidx.compose.ui:ui-tooling-preview:$composeVersion"
     implementation 'androidx.compose.material3:material3:1.1.1'
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$composeVersion"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$composeVersion"
+    implementation 'androidx.emoji2:emoji2:1.4.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.itextpdf:itext7-core:7.2.5'
 }

--- a/PA/mobilePrestataires/app/src/androidTest/java/com/example/ecodeli/ui/MainActivityTest.kt
+++ b/PA/mobilePrestataires/app/src/androidTest/java/com/example/ecodeli/ui/MainActivityTest.kt
@@ -1,0 +1,20 @@
+package com.example.ecodeli.ui
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun mainActivityDisplaysPdfButton() {
+        composeTestRule.onNodeWithText("Generer PDF").assertIsDisplayed()
+    }
+}

--- a/PA/mobilePrestataires/app/src/main/AndroidManifest.xml
+++ b/PA/mobilePrestataires/app/src/main/AndroidManifest.xml
@@ -4,8 +4,7 @@
     <application
         android:allowBackup="true"
         android:label="EcoDeli"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        android:supportsRtl="true">
         <activity
             android:name="com.example.ecodeli.ui.MainActivity"
             android:exported="true">

--- a/PA/mobilePrestataires/app/src/main/res/values/colors.xml
+++ b/PA/mobilePrestataires/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/PA/mobilePrestataires/app/src/main/res/values/strings.xml
+++ b/PA/mobilePrestataires/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">EcoDeli</string>
+</resources>

--- a/PA/mobilePrestataires/app/src/main/res/values/themes.xml
+++ b/PA/mobilePrestataires/app/src/main/res/values/themes.xml
@@ -1,0 +1,3 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.EcoDeli" parent="Theme.Material3.DayNight.NoActionBar"/>
+</resources>

--- a/PA/mobilePrestataires/build.gradle
+++ b/PA/mobilePrestataires/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
     ext {
-        compose_ui_version = '1.5.0'
+        compose_ui_version = '1.5.1'
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
+        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10'
     }
 }
 


### PR DESCRIPTION
## Summary
- use Android Gradle Plugin 8.2.0
- target Android SDK 34 and configure Java/Kotlin 17
- remove missing Material3 theme
- add Emoji2 dependency
- bump Compose to 1.5.1 and add minimal instrumented test

## Testing
- `gradle -q projects` *(fails: Could not resolve gradle dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5fb056483228c5253506bf83430